### PR TITLE
Define types for serialization

### DIFF
--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -1,4 +1,4 @@
-package serialize
+package api
 
 import "fmt"
 

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -1,0 +1,70 @@
+package serialize
+
+import "fmt"
+
+type ErrorKind string
+
+func (e ErrorKind) MarshalText() ([]byte, error) {
+	return []byte(e), nil
+}
+
+// AuthorizationErrorKind codes
+var (
+	ErrUserIdInvalid       ErrorKind = "user-id-invalid"
+	ErrOnlyOwnerAllowed    ErrorKind = "only-owned-allowed"
+	ErrAuthRequired        ErrorKind = "auth-required"
+	ErrNotEnoughPrivileges ErrorKind = "not-enough-privileges"
+)
+
+// ImageErrorKind codes
+var (
+	ErrImgNotProvided       ErrorKind = "img-not-provided"
+	ErrImgTooLarge          ErrorKind = "img-too-large"
+	ErrImgFormatUnsupported ErrorKind = "img-format-unsupported"
+	ErrImgMalformed         ErrorKind = "img-malformed"
+	ErrImgUploadForbidden   ErrorKind = "img-upload-forbidden"
+)
+
+// InvalidParamErrorKind codes
+var (
+	ErrSchemaInvalid ErrorKind = "schema-invalid"
+	ErrParamMissing  ErrorKind = "param-missing"
+	ErrParamInvalid  ErrorKind = "param-invalid"
+)
+
+// TaskErrorKind codes
+var (
+	ErrTaskNotFound ErrorKind = "task-not-found"
+	ErrTaskInvalid  ErrorKind = "task-invalid"
+	ErrTaskUsed     ErrorKind = "task-used"
+)
+
+// GameErrorKind codes
+var (
+	ErrGameInvalid ErrorKind = "game-invalid"
+)
+
+// GeneralErrorKind codes
+var (
+	ErrNotFound ErrorKind = "not-found"
+)
+
+type Error struct {
+	Kind    ErrorKind `json:"error"`
+	Message string    `json:"message"`
+}
+
+func Errorf(kind ErrorKind, format string, a ...any) *Error {
+	return &Error{
+		Kind:    kind,
+		Message: fmt.Sprintf(format, a...),
+	}
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%v (code `%v`)", e.Message, e.Kind)
+}
+
+func (e *Error) String() string {
+	return e.Message
+}

--- a/internal/ws/schema.go
+++ b/internal/ws/schema.go
@@ -1,0 +1,105 @@
+package serialize
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type MessageKind string
+
+var (
+	MsgKindError      MessageKind = "error"
+	MsgKindJoin       MessageKind = "join"
+	MsgKindJoined     MessageKind = "joined"
+	MsgKindGameStatus MessageKind = "game-status"
+	MsgKindReady      MessageKind = "ready"
+	MsgKindKick       MessageKind = "kick"
+	MsgKindLeave      MessageKind = "leave"
+	MsgKindTaskStart  MessageKind = "task-start"
+	MsgKindTaskAnswer MessageKind = "task-answer"
+	MsgKindPollStart  MessageKind = "poll-start"
+	MsgKindPollChoose MessageKind = "poll-choose"
+	MsgKindTaskEnd    MessageKind = "task-end"
+	MsgKindGameEnd    MessageKind = "game-end"
+	MsgKindGameStart  MessageKind = "game-start"
+	MsgKindWaiting    MessageKind = "waiting"
+)
+
+func (m MessageKind) MarshalText() ([]byte, error) {
+	return []byte(m), nil
+}
+
+type MessageId uint32
+
+func (id MessageId) String() string {
+	return fmt.Sprint(uint32(id))
+}
+
+// A Time wraps a time.Time to provide a session protocol-compliant JSON encoding.
+// Its value is represented as a Unix timestamp (a 64-bit integer).
+type Time time.Time
+
+func (t Time) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Time(t).UnixMilli())
+}
+
+type BaseMessage struct {
+	MsgId MessageId   `json:"msg-id"`
+	Kind  MessageKind `json:"kind"`
+	Time  Time        `json:"time"`
+}
+
+type ErrorKind string
+
+func (e ErrorKind) MarshalText() ([]byte, error) {
+	return []byte(e), nil
+}
+
+// GeneralErrorKind codes
+var (
+	ErrInternal       ErrorKind = "internal"
+	ErrMalformedMsg   ErrorKind = "malformed-msg"
+	ErrProtoViolation ErrorKind = "proto-violation"
+)
+
+// JoinErrorKind codes
+var (
+	ErrSessionExpired ErrorKind = "session-expired"
+	ErrLobbyFull      ErrorKind = "lobby-full"
+	ErrNicknameUsed   ErrorKind = "nickname-used"
+)
+
+// OpErrorKind codes
+var (
+	ErrOpOnly ErrorKind = "op-only"
+)
+
+// GameErrorKind codes
+var (
+	ErrInactivity    ErrorKind = "inactivity"
+	ErrSessionClosed ErrorKind = "session-closed"
+)
+
+type Error struct {
+	RefId   *MessageId `json:"ref-id"`
+	Code    ErrorKind  `json:"code"`
+	Message string     `json:"message"`
+}
+
+func (e *Error) Error() string {
+	if e.RefId == nil {
+		return fmt.Sprintf("%v (code `%v`)", e.Message, e.Code)
+	} else {
+		return fmt.Sprintf("%v (code `%v`, reply to msg %v)", e.Message, e.Code, e.RefId)
+	}
+}
+
+func (e *Error) String() string {
+	return e.Message
+}
+
+type MessageError struct {
+	BaseMessage
+	Error
+}

--- a/internal/ws/schema.go
+++ b/internal/ws/schema.go
@@ -1,4 +1,4 @@
-package serialize
+package ws
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Модули отдельно для сериализации и в будущем десериализации решил не делать: путаются под ногами различные типы ошибок. Вместо этого разделил на API-часть и на WebSockets-часть. Там будут потом пересечения для описания игр, которые и там, и там юзаются: посмотрим, куда их добавлять (возможно, отдельный пакет придётся выделить).