### PR TITLE
fix: validation and deadline timer init

### DIFF
--- a/internal/api/handlers/session.go
+++ b/internal/api/handlers/session.go
@@ -158,7 +158,7 @@ func (sch SessionCreateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusInternalServerError)
-	var dto *api.Error
+	var dto api.Error
 	errors.As(err, &dto)
 	_ = encoder.Encode(dto)
 	log.Printf("request: %v %s -> err: %v", r.Method, r.URL, dto)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -78,7 +78,7 @@ outer:
 					sid:      msg.sid,
 					rx:       msg.rx,
 					log:      logger,
-					deadline: *time.NewTimer(NoOwnerTimeout),
+					deadline: time.NewTimer(NoOwnerTimeout),
 				}
 				group.Go(func() error {
 					return updater.run(ctx)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -74,10 +74,11 @@ outer:
 					log.Default().Flags(),
 				)
 				updater := sessionUpdater{
-					m:   m,
-					sid: msg.sid,
-					rx:  msg.rx,
-					log: logger,
+					m:        m,
+					sid:      msg.sid,
+					rx:       msg.rx,
+					log:      logger,
+					deadline: *time.NewTimer(NoOwnerTimeout),
 				}
 				group.Go(func() error {
 					return updater.run(ctx)

--- a/internal/session/update.go
+++ b/internal/session/update.go
@@ -42,7 +42,7 @@ type sessionUpdater struct {
 	sid      SessionID
 	rx       <-chan updateMsg
 	log      *log.Logger
-	deadline time.Timer
+	deadline *time.Timer
 }
 
 func (u *sessionUpdater) run(ctx context.Context) error {

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -1,0 +1,20 @@
+package util
+
+func SymbolsCount(s string) int {
+	return len([]rune(s))
+}
+
+func MaxLengthPChecker(c int) func(v *string) bool {
+	return func(v *string) bool {
+		if v == nil {
+			return false
+		}
+		return SymbolsCount(*v) <= c
+	}
+}
+
+func MaxLengthChecker(c int) func(v string) bool {
+	return func(v string) bool {
+		return SymbolsCount(v) <= c
+	}
+}


### PR DESCRIPTION
Обнаружено и исправлено несколько багов:
- ограничение на длину считалось адекватно только для английских символов
- не проверялось наличие img-request
- ошибка десериализации не писалась в лог
- timer для updater не был проинициализирован