### PR TITLE
Use uint32 instead of UUID as the backing type for PlayerID

### DIFF
--- a/internal/schemas/ws/ws_schema.go
+++ b/internal/schemas/ws/ws_schema.go
@@ -491,7 +491,7 @@ type MessageJoined struct {
 	BaseMessage
 
 	RefID    *MessageID          `json:"ref-id"`
-	PlayerID uuid.UUID           `json:"player-id"`
+	PlayerID uint32              `json:"player-id"`
 	Sid      uuid.UUID           `json:"session-id"`
 	Game     schemas.GameDetails `json:"game"`
 }
@@ -499,8 +499,8 @@ type MessageJoined struct {
 func (*MessageJoined) isRespMessage() {}
 
 type Player struct {
-	PlayerID uuid.UUID `json:"player-id"`
-	Nickname string    `json:"nickname"`
+	PlayerID uint32 `json:"player-id"`
+	Nickname string `json:"nickname"`
 }
 
 type MessageGameStatus struct {
@@ -563,9 +563,9 @@ type TaskOptionAnswer struct {
 func (*TaskOptionAnswer) isAnswer() {}
 
 type TaskPlayerScore struct {
-	PlayerID    uuid.UUID `json:"player-id"`
-	TaskPoints  uint32    `json:"task-points"`
-	TotalPoints uint32    `json:"total-points"`
+	PlayerID    uint32 `json:"player-id"`
+	TaskPoints  uint32 `json:"task-points"`
+	TotalPoints uint32 `json:"total-points"`
 }
 
 type MessageTaskEnd struct {
@@ -590,14 +590,14 @@ func (*MessageGameStart) isRespMessage() {}
 type MessageWaiting struct {
 	BaseMessage
 
-	Ready []uuid.UUID `json:"ready"`
+	Ready []uint32 `json:"ready"`
 }
 
 func (*MessageWaiting) isRespMessage() {}
 
 type GamePlayerScore struct {
-	PlayerID    uuid.UUID `json:"player-id"`
-	TotalPoints uint32    `json:"total-points"`
+	PlayerID    uint32 `json:"player-id"`
+	TotalPoints uint32 `json:"total-points"`
 }
 
 type MessageGameEnd struct {

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -69,6 +69,8 @@ func (s *UnsafeStorage) newPlayerID(sid SessionID) PlayerID {
 
 	for id := session.nextPlayerID; ; id++ {
 		if _, ok := session.players[id]; !ok {
+			session.nextPlayerID = id + 1
+
 			return id
 		}
 	}

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -22,9 +22,9 @@ type (
 
 	// A PlayerID identifies a particular player in a session.
 	//
-	// It is generated randomly when a client joins and is only valid in the context of the session.
+	// It is generated when a client joins and is only valid in the context of the session.
 	// Unlike their [ClientID], the client's PlayerID is shared among other session players.
-	PlayerID uuid.UUID
+	PlayerID uint32
 
 	// A ClientID identifies a particular client.
 	// The ClientID is a secret value that is used for access control;
@@ -44,10 +44,6 @@ func (id ImageID) String() string {
 
 func (sid SessionID) UUID() uuid.UUID {
 	return uuid.UUID(sid)
-}
-
-func (id PlayerID) UUID() uuid.UUID {
-	return uuid.UUID(id)
 }
 
 func (id ClientID) UUID() uuid.UUID {
@@ -70,16 +66,8 @@ func (sid SessionID) String() string {
 	return sid.UUID().String()
 }
 
-func NewPlayerID() PlayerID {
-	uuid, err := uuid.NewRandom()
-	if err != nil {
-		panic(fmt.Sprintf("could not generate player id: %v", err))
-	}
-	return PlayerID(uuid)
-}
-
 func (id PlayerID) String() string {
-	return id.UUID().String()
+	return fmt.Sprintf("%d", uint32(id))
 }
 
 // An InviteCode is a short code used for session discovery.
@@ -122,6 +110,7 @@ type session struct {
 	id            SessionID
 	game          Game
 	players       map[PlayerID]Player
+	nextPlayerID  PlayerID
 	playersMax    int
 	clients       map[ClientID]PlayerID
 	bannedClients map[ClientID]struct{}

--- a/internal/ws/converters/game_end.go
+++ b/internal/ws/converters/game_end.go
@@ -11,7 +11,7 @@ func ToMessageGameEnd(m session.MsgGameEnd) ws.MessageGameEnd {
 
 	for _, score := range m.Scoreboard.Scores() {
 		scores = append(scores, ws.GamePlayerScore{
-			PlayerID:    score.PlayerID.UUID(),
+			PlayerID:    uint32(score.PlayerID),
 			TotalPoints: uint32(score.Score),
 		})
 	}

--- a/internal/ws/converters/game_status.go
+++ b/internal/ws/converters/game_status.go
@@ -11,7 +11,7 @@ func ToMessageGameStatus(m session.MsgGameStatus) ws.MessageGameStatus {
 
 	for _, player := range m.Players {
 		players = append(players, ws.Player{
-			PlayerID: player.ID.UUID(),
+			PlayerID: uint32(player.ID),
 			Nickname: player.Nickname,
 		})
 	}

--- a/internal/ws/converters/join.go
+++ b/internal/ws/converters/join.go
@@ -73,7 +73,7 @@ func ToMessageJoined(m session.MsgJoined) ws.MessageJoined {
 	msg := ws.MessageJoined{}
 	msg.BaseMessage = utils.GenBaseMessage(&ws.MsgKindJoined)
 	msg.Sid = m.SessionID.UUID()
-	msg.PlayerID = m.PlayerID.UUID()
+	msg.PlayerID = uint32(m.PlayerID)
 	msg.Game = ToGameDetails(*m.Game)
 	return msg
 }

--- a/internal/ws/converters/task_end.go
+++ b/internal/ws/converters/task_end.go
@@ -16,7 +16,7 @@ func ToMessageTaskEnd(m session.MsgTaskEnd) ws.MessageTaskEnd {
 
 	for _, score := range m.Scoreboard.Scores() {
 		msg.Scoreboard = append(msg.Scoreboard, ws.TaskPlayerScore{
-			PlayerID:    score.PlayerID.UUID(),
+			PlayerID:    uint32(score.PlayerID),
 			TaskPoints:  uint32(m.Winners[score.PlayerID]),
 			TotalPoints: uint32(score.Score),
 		})

--- a/internal/ws/converters/waiting.go
+++ b/internal/ws/converters/waiting.go
@@ -4,15 +4,13 @@ import (
 	"party-buddy/internal/schemas/ws"
 	"party-buddy/internal/session"
 	"party-buddy/internal/ws/utils"
-
-	"github.com/google/uuid"
 )
 
 func ToMessageWaiting(m session.MsgWaiting) ws.MessageWaiting {
-	var ready []uuid.UUID
+	var ready []uint32
 
 	for playerID := range m.PlayersReady {
-		ready = append(ready, playerID.UUID())
+		ready = append(ready, uint32(playerID))
 	}
 
 	return ws.MessageWaiting{


### PR DESCRIPTION
Нам повезло, что с архитектурной точки зрения всё правильно спроектировано, поэтому поменять вышло совсем несложно.

См. Party-Buddy/docs#15.